### PR TITLE
Fix SatelMessage initialization

### DIFF
--- a/satel_integra_ext/satel_integra.py
+++ b/satel_integra_ext/satel_integra.py
@@ -93,11 +93,11 @@ class SatelMessage(object):
                  outputs=None):
         self.cmd = cmd
         self.msg_data = msg_data if msg_data else bytearray()
-        if code:
+        if code is not None:
             self.msg_data += bytearray.fromhex(code.ljust(16, 'F'))
-        if partitions:
+        if partitions is not None:
             self.msg_data += partition_bytes(partitions, 4)
-        if outputs:
+        if outputs is not None:
             self.msg_data += partition_bytes(outputs, 32)
 
     def compare_cmd(self, other):


### PR DESCRIPTION
I was using the simulator to test some new Home Assistant functionality (UI config and more), however, when the initial boot of the simulator is done and connections come in, it broadcasts the outputs and partitions (as a normal panel does). The problem is that all partitions (for example, outputs have the same issue) are in the Disarmed state, so the message gets initialized with an empty array. The old check actually does not go through, because the if statement considers an empty array as false. This new check makes sure the parameters are actually None and properly constructs the messages to be send back.